### PR TITLE
FIX: don't display DISQUS on Draft pages

### DIFF
--- a/code/DisqusDecorator.php
+++ b/code/DisqusDecorator.php
@@ -53,7 +53,11 @@ class DisqusDecorator extends DataExtension {
 			return (Director::isLive()) ? NULL : "var disqus_developer = 1;";
 	}
 			
-	function DisqusPageComments() {		
+	function DisqusPageComments() {
+		// if the owner DataObject is Versioned, don't display DISQUS until the post is published
+		// to avoid identifier / URL conflicts.
+		if( $this->owner->hasExtension('Versioned') && Versioned::current_stage() == 'Stage') return;
+
 		$config = SiteConfig::current_site_config();
 		$ti = $this->disqusIdentifier();
 		if ($config->disqus_shortname && $this->owner->ProvideComments) {


### PR DESCRIPTION
This helps to prevent identifier conflict with DISQUS threads, the issue occurs when viewing the page before publishing (i.e. the preview window) the thread gets assigned to the "new-page" url, as do future pages.

Documented on DISQUS here; http://help.disqus.com/customer/portal/articles/662547-why-are-the-same-comments-showing-up-on-multiple-pages-
