### PR TITLE
FIX: don't display DISQUS on Draft pages

### DIFF
--- a/code/DisqusDecorator.php
+++ b/code/DisqusDecorator.php
@@ -53,6 +53,10 @@ class DisqusDecorator extends DataObjectDecorator {
 	}
 			
 	function DisqusPageComments() {		
+		// if the owner DataObject is Versioned, don't display DISQUS until the post is published
+		// to avoid identifier / URL conflicts.
+		if( $this->owner->hasExtension('Versioned') && Versioned::current_stage() == 'Stage') return;
+
 		$config = SiteConfig::current_site_config();
 		$ti = $this->disqusIdentifier();
 		if ($config->disqus_shortname && $this->owner->ProvideComments) {


### PR DESCRIPTION
The same fix that I sent to master (v3) branch last week to the 2.4 branch
