### PR TITLE
Update installer name so composer install creates 'disqus' folder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,5 +8,8 @@
         "php": ">=5.3.2",
         "silverstripe/framework": "~3.1",
         "silverstripe/cms": "~3.1"
+    },
+    "extra":{
+        "installer-name": "disqus"
     }
 }


### PR DESCRIPTION
Helps composer clone this automatically into a folder called 'disqus' rather than 'silverstripe-disqus'
