### PR TITLE
Fix up URLs so they use https which is now required by Disqus

### DIFF
--- a/code/DisqusCount.php
+++ b/code/DisqusCount.php
@@ -22,7 +22,7 @@ class DisqusCount  {
 			    (function () {
 			        var s = document.createElement('script'); s.async = true;
 			        s.type = 'text/javascript';
-			        s.src = 'http://' + disqus_shortname + '.disqus.com/count.js';
+			        s.src = 'https://' + disqus_shortname + '.disqus.com/count.js';
 			        (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
 			    }());
 			    ";

--- a/code/DisqusDecorator.php
+++ b/code/DisqusDecorator.php
@@ -70,7 +70,7 @@ class DisqusDecorator extends DataExtension {
 				
 			    (function() {
 			        var dsq = document.createElement(\'script\'); dsq.type = \'text/javascript\'; dsq.async = true;
-			        dsq.src = \'http://\' + disqus_shortname + \'.disqus.com/embed.js\';
+			        dsq.src = \'https://\' + disqus_shortname + \'.disqus.com/embed.js\';
 			        (document.getElementsByTagName(\'head\')[0] || document.getElementsByTagName(\'body\')[0]).appendChild(dsq);
 			    })();				
 			';
@@ -107,7 +107,7 @@ class DisqusDecorator extends DataExtension {
 				if (($now - $synced) > $config->disqus_synctime) {
 					if ($config->disqus_syncinbg) {
 						// background process
-						// from here: http://stackoverflow.com/questions/1993036/run-function-in-background
+						// from here: https://stackoverflow.com/questions/1993036/run-function-in-background
 					    // TODO: Windows check is not fully correct
 					    // Debug
 					    // echo "trying to sync in BG";

--- a/templates/Includes/DisqusComments.ss
+++ b/templates/Includes/DisqusComments.ss
@@ -16,5 +16,5 @@
 <div id="disqus_thread">
 
 </div>
-<noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
-<p><a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a></p>
+<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
+<p><a href="https://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a></p>


### PR DESCRIPTION
Update the Disqus URLs to be https so the Disqus comments will show.  Fixes #10
